### PR TITLE
Added tests to Bandwidth class

### DIFF
--- a/DownloaderNET.Tests/BandwidthTests.cs
+++ b/DownloaderNET.Tests/BandwidthTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc.Diagnostics;
+using Xunit.Abstractions;
+
+namespace DownloaderNET.Tests;
+
+public class BandwidthTests
+{
+
+
+    private const int OncSec = 1000;
+
+    [Fact]
+    public void BandwidthSpeedLimit()
+    {
+        var mockCounter = new MockTickCounter();
+        var limit = 10000;
+        var b = new Bandwidth(limit, mockCounter);
+
+        mockCounter.Counter += OncSec * 2;
+        b.CalculateSpeed(limit * 2);
+        Assert.Equal(limit, b.Speed);
+
+    }
+
+    [Fact]
+    public void BandwidthSpeedHalfLimit()
+    {
+        var mockCounter = new MockTickCounter();
+        var limit = 5000;
+        var b = new Bandwidth(limit * 2, mockCounter);
+
+        mockCounter.Counter += OncSec * 2;
+        b.CalculateSpeed(limit * 2);
+        Assert.Equal(limit, b.Speed);
+    }
+
+    [Fact]
+    public void BandwidthPopSpeedRetrieveTime()
+    {
+        var mockCounter = new MockTickCounter();
+        var limit = 10000;
+        var b = new Bandwidth(limit, mockCounter);
+
+        mockCounter.Counter += OncSec * 2;
+        b.CalculateSpeed(limit * 3);
+        Assert.Equal(1000, b.PopSpeedRetrieveTime());
+
+    }
+}

--- a/DownloaderNET.Tests/MockTickCounter.cs
+++ b/DownloaderNET.Tests/MockTickCounter.cs
@@ -1,0 +1,12 @@
+
+
+class MockTickCounter : ITickCounter
+{
+
+    public int Counter = 0;
+
+    int ITickCounter.GetTickCount()
+    {
+        return Counter & int.MaxValue;
+    }
+}

--- a/DownloaderNET/DownloaderNET.csproj
+++ b/DownloaderNET/DownloaderNET.csproj
@@ -20,5 +20,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DownloaderNET.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/DownloaderNET/ITickCounter.cs
+++ b/DownloaderNET/ITickCounter.cs
@@ -1,0 +1,7 @@
+
+
+
+internal interface ITickCounter
+{
+    int GetTickCount();
+}

--- a/DownloaderNET/TickCounter.cs
+++ b/DownloaderNET/TickCounter.cs
@@ -4,6 +4,13 @@ class TickCounter : ITickCounter
     {
     }
 
+
+
+    /// <summary>
+    /// Retrieves the number of milliseconds that have elapsed since the system was started, up 
+    /// to 24.9 days. After 24.9 days this will start again from 0.
+    /// </summary>
+    /// <returns>milliseconds since system start</returns>
     int ITickCounter.GetTickCount()
     {
         return Environment.TickCount & int.MaxValue;

--- a/DownloaderNET/TickCounter.cs
+++ b/DownloaderNET/TickCounter.cs
@@ -1,0 +1,11 @@
+class TickCounter : ITickCounter
+{
+    public TickCounter()
+    {
+    }
+
+    int ITickCounter.GetTickCount()
+    {
+        return Environment.TickCount & int.MaxValue;
+    }
+}


### PR DESCRIPTION
I was looking in to https://github.com/rogerfar/rdt-client/issues/579 and how the downloader for RTD worked and i saw that the bandwidth class did not have any tests.

While adding the test i saw that there was a potential division by zero bug on the elapsedTime in CalculateSpeed, so i fixed that.