### PR TITLE
Fix off by one error with `Content-Size`/`Range` headers

### DIFF
--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -182,7 +182,7 @@ public class Downloader : IDisposable
 
         for (var startByte = 0L; startByte < contentSize; startByte += _settings.ChunkSize)
         {
-            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize);
+            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize - 1);
             var length = endByte - startByte;
 
             Log($"Add chunk {startByte} - {endByte} ({length})", -1);


### PR DESCRIPTION
If `Content-Length` is `32`, then the maximum allowable `Range` is `bytes=0-31` *not* `32`.

I'll try and figure out how to add a test for this