### PR TITLE
Fix off by one error with Content-Size/Range headers

### DIFF
--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -182,7 +182,7 @@ public class Downloader : IDisposable
 
         for (var startByte = 0L; startByte < contentSize; startByte += _settings.ChunkSize)
         {
-            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize);
+            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize - 1);
             var length = endByte - startByte;
 
             Log($"Add chunk {startByte} - {endByte} ({length})", -1);


### PR DESCRIPTION
If Content-Length is 32, then the maximum allowable Range is bytes=0-31 not 32.

I initially intended to write a test/modify the existing tests to handle this case. I did some stuff in [`8ad8480`](https://github.com/Cucumberrbob/Downloader.NET/commit/8ad8480) - `ChunkOverBuffer` passes before this commit, fails after this commit with `System.Exception: Failed to download bytes from range 315392-318894. Status code: RequestedRangeNotSatisfiable`, and after cherry picking the commit in this PR onto `8ad8480`, passes again.

I've been struggling to get all the tests to work - it seems that at least some of them only pass when run individually. I'm primarily testing with JetBrains Rider's built in test browser on my aarch64-darwin machine, but I've also tried on my x86_64-linux with `dotnet test` to similar results.