### PR TITLE
Add `dotnet test` GitHub Action, make tests work/less flaky

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,0 +1,24 @@
+name: dotnet test
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/DownloaderNET.Tests/BaseTest.cs
+++ b/DownloaderNET.Tests/BaseTest.cs
@@ -136,7 +136,7 @@ public class BaseTest
     {
         StartServer(options);
 
-        await Task.Delay(10);
+        await Task.Delay(50);
 
         var fn = Path.Combine(_root!, $"result.bin");
 

--- a/DownloaderNET.Tests/BaseTest.cs
+++ b/DownloaderNET.Tests/BaseTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Collections.Concurrent;
+using System.Net.Http.Headers;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -16,7 +17,7 @@ public class BaseTest
 
     private void StartServer(Options options)
     {
-        var retries = new Dictionary<String, Int32>();
+        var retries = new ConcurrentDictionary<String, Int32>();
 
         var builder = WebApplication.CreateBuilder();
 
@@ -46,7 +47,7 @@ public class BaseTest
 
                                  if (context.Request.Method == "HEAD")
                                  {
-                                     retries = new Dictionary<String, Int32>();
+                                     retries.Clear();
 
                                      var sb = new StringBuilder();
                                      for (var i = 1; i <= options.ServerSize; i++)

--- a/DownloaderNET.Tests/BaseTest.cs
+++ b/DownloaderNET.Tests/BaseTest.cs
@@ -136,6 +136,8 @@ public class BaseTest
     {
         StartServer(options);
 
+        await Task.Delay(10);
+
         var fn = Path.Combine(_root!, $"result.bin");
 
         var tcs = new TaskCompletionSource<Boolean>();

--- a/DownloaderNET.Tests/DownloaderTests.cs
+++ b/DownloaderNET.Tests/DownloaderTests.cs
@@ -64,7 +64,7 @@ public class DownloaderTests : BaseTest
         await Assert.ThrowsAsync<HttpIOException>(() => Download(new Options
         {
             Parallel = parallel,
-            ServerFailAfterBytes = 328893
+            ServerFailAfterBytes = 318893
         }));
     }
     
@@ -77,7 +77,7 @@ public class DownloaderTests : BaseTest
         await Assert.ThrowsAsync<HttpIOException>(() => Download(new Options
         {
             Parallel = parallel,
-            ServerFailAfterBytes = 328893,
+            ServerFailAfterBytes = 318893,
             DownloaderRetryCount = 1
         }));
     }

--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -467,7 +467,7 @@ public class Downloader : IDisposable
                     }
                     catch (Exception ex)
                     {
-                        if (!ex.Message.Contains("The response ended prematurely"))
+                        if (ex.Message.Contains("The response ended prematurely"))
                         {
                             throw;
                         }


### PR DESCRIPTION
Fixes #6 

TL;DR of that issue is that some of the tests either don't work, or are flaky. This PR makes them all work and stops them being as flaky.

On my fork I have a bunch of GitHub Actions runs of this workflow. Look at the runs from just the GitHub workflow file being added [here](https://github.com/Cucumberrbob/Downloader.NET/actions/runs/13143844053), and the ones from this PR [here](https://github.com/Cucumberrbob/Downloader.NET/actions/runs/13142700494). There are multiple attempts for both of those.

This PR fixes the tests by:
- Throwing `Response ended prematurely` errors rather than catching them and doing nothing (fixes tests)
- Waiting 50ms after starting the mock server before trying to download from it (reduces flakiness)
- Using a `ServerFailAfterBytes` smaller than the `Content-Length` of the file (fixes test)
- Using a `ConcurrentDictionary` rather than a `Dictionary` (reduces flakiness)