### PR TITLE
fix off by one `RangeTo` in `Downloader` and `BaseTest`

### DIFF
--- a/DownloaderNET.Tests/BaseTest.cs
+++ b/DownloaderNET.Tests/BaseTest.cs
@@ -77,7 +77,7 @@ public class BaseTest
 
                                  if (rangeFrom.HasValue && rangeTo.HasValue)
                                  {
-                                     file = file.AsSpan(rangeFrom.Value, rangeTo.Value - rangeFrom.Value).ToArray();
+                                     file = file.AsSpan(rangeFrom.Value, rangeTo.Value - rangeFrom.Value + 1).ToArray();
                                  }
 
                                  var fileStream = new MemoryStream();

--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -182,7 +182,7 @@ public class Downloader : IDisposable
 
         for (var startByte = 0L; startByte < contentSize; startByte += _settings.ChunkSize)
         {
-            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize);
+            var endByte = Math.Min(startByte + _settings.ChunkSize, contentSize - 1);
             var length = endByte - startByte;
 
             Log($"Add chunk {startByte} - {endByte} ({length})", -1);


### PR DESCRIPTION
Another attempt at getting #5 merged.

Also see [this comment](https://github.com/rogerfar/Downloader.NET/pull/5#issuecomment-2656409426) explaining why the change is necessary, and why the tests failed after merging #5.