### PR TITLE
Fix fast download speeds (>400 Mbps) are reported as 0 B/s

### DIFF
--- a/DownloaderNET/Bandwidth.cs
+++ b/DownloaderNET/Bandwidth.cs
@@ -4,7 +4,7 @@ internal class Bandwidth
 {
     public Double Speed { get; private set; }
 
-    private const Double OneSecond = 1000;
+    private const Double Period = 500; // Speed is updated every Period milliseconds. Before first Period finishes, Speed is zero.
 
     private readonly Int64 _bandwidthLimit;
 
@@ -26,9 +26,9 @@ internal class Bandwidth
     {
         var elapsedTime = Math.Max(_tickCounter.GetTickCount() - _lastSecondCheckpoint, 1);
         receivedBytesCount = Interlocked.Add(ref _lastTransferredBytesCount, receivedBytesCount);
-        var momentSpeed = receivedBytesCount * OneSecond / elapsedTime;
+        var momentSpeed = receivedBytesCount * Period / elapsedTime;
 
-        if (OneSecond < elapsedTime)
+        if (Period < elapsedTime)
         {
             Speed = momentSpeed;
             SecondCheckpoint();
@@ -36,7 +36,7 @@ internal class Bandwidth
 
         if (momentSpeed >= _bandwidthLimit)
         {
-            var expectedTime = receivedBytesCount * OneSecond / _bandwidthLimit;
+            var expectedTime = receivedBytesCount * Period / _bandwidthLimit;
             Interlocked.Add(ref _speedRetrieveTime, (Int32)expectedTime - elapsedTime);
         }
     }

--- a/DownloaderNET/Bandwidth.cs
+++ b/DownloaderNET/Bandwidth.cs
@@ -4,6 +4,7 @@ internal class Bandwidth
 {
     public Double Speed { get; private set; }
 
+    private const Double OneSecond = 1000;
     private const Double Period = 500; // Speed is updated every Period milliseconds. Before first Period finishes, Speed is zero.
 
     private readonly Int64 _bandwidthLimit;
@@ -26,7 +27,7 @@ internal class Bandwidth
     {
         var elapsedTime = Math.Max(_tickCounter.GetTickCount() - _lastSecondCheckpoint, 1);
         receivedBytesCount = Interlocked.Add(ref _lastTransferredBytesCount, receivedBytesCount);
-        var momentSpeed = receivedBytesCount * Period / elapsedTime;
+        var momentSpeed = receivedBytesCount * OneSecond / elapsedTime;
 
         if (Period < elapsedTime)
         {
@@ -36,7 +37,7 @@ internal class Bandwidth
 
         if (momentSpeed >= _bandwidthLimit)
         {
-            var expectedTime = receivedBytesCount * Period / _bandwidthLimit;
+            var expectedTime = receivedBytesCount * OneSecond / _bandwidthLimit;
             Interlocked.Add(ref _speedRetrieveTime, (Int32)expectedTime - elapsedTime);
         }
     }

--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -329,9 +329,13 @@ public class Downloader : IDisposable
             {
                 _settings.ChunkSize = 1024 * 1024 * 100;
             }
-            else
+            else if (contentSize <= 1024 * 1024 * 1024 * 4)
             {
                 _settings.ChunkSize = 1024 * 1024 * 250;
+            }
+            else
+            {
+                _settings.ChunkSize = 1024 * 1024 * 750;
             }
 
             Log($"Setting chunk size to {_settings.ChunkSize}", -1);

--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -312,11 +312,11 @@ public class Downloader : IDisposable
 
         if (_settings.ChunkSize == 0)
         {
-            // With high speed downstream speed, if chunk size is too small we can download each chunk
+            // With high downstream speed, if chunk size is too small we can download each chunk
             // super quick even before speed is calculated for the first time. Resulting in
             // speed being reported as 0 B/s throughout the download.
             //
-            // This only matters when file itself is big enough to actually see the 0 B/s for some time.
+            // This only matters when file itself is big enough for user to actually notice the 0 B/s.
             if (contentSize <= 1024 * 1024 * 50)
             {
                 _settings.ChunkSize = 1024 * 1024 * 10;

--- a/DownloaderNET/Downloader.cs
+++ b/DownloaderNET/Downloader.cs
@@ -312,17 +312,26 @@ public class Downloader : IDisposable
 
         if (_settings.ChunkSize == 0)
         {
-            if (contentSize <= 1024 * 1024 * 10)
+            // With high speed downstream speed, if chunk size is too small we can download each chunk
+            // super quick even before speed is calculated for the first time. Resulting in
+            // speed being reported as 0 B/s throughout the download.
+            //
+            // This only matters when file itself is big enough to actually see the 0 B/s for some time.
+            if (contentSize <= 1024 * 1024 * 50)
             {
                 _settings.ChunkSize = 1024 * 1024 * 10;
             }
-            else if (contentSize <= 1024 * 1024 * 100)
+            else if (contentSize <= 1024 * 1024 * 500)
             {
                 _settings.ChunkSize = 1024 * 1024 * 25;
             }
+            else if (contentSize <= 1024 * 1024 * 1024)
+            {
+                _settings.ChunkSize = 1024 * 1024 * 100;
+            }
             else
             {
-                _settings.ChunkSize = 1024 * 1024 * 50;
+                _settings.ChunkSize = 1024 * 1024 * 250;
             }
 
             Log($"Setting chunk size to {_settings.ChunkSize}", -1);


### PR DESCRIPTION
### **User description**
This is an attempt to fix https://github.com/rogerfar/rdt-client/issues/831 that on high speed connections, speed is constantly showed as 0 B/s.

### Root cause
- To download a file we break it into chunks.
- According to `CalculateChunks` a chunk is at max 50MB.
- In https://github.com/rogerfar/Downloader.NET/blob/07e5d382a04fcdee387e35b25f0158a6ba337395/DownloaderNET/Downloader.cs#L451 we make a new bandwith object per chunk.
- If you have a downstream speed >400Mbps, a 50MB file can be downloaded under a second.
- In https://github.com/rogerfar/Downloader.NET/blob/07e5d382a04fcdee387e35b25f0158a6ba337395/DownloaderNET/Bandwidth.cs#L31 we update download speed every second.
- All of this will lead to speed of every chunk to never change from default value of 0.

### Solution
To make a permanent fix, we need to calculate speed every moment that leads to volatile number displayed to the user, and then we somehow need to smooth that number with a moving average or similar method. I chose a simpler path because I'm lazy 😅 :
- Change calculation frequency from 1s to 500ms
- Increase chunk size when file size is pretty big

With these changes a multi gigabyte file is split into 750MB chunks. To download a 750MB chunk in 500ms, you need 750*8/0.5 = 12Gbps that is not available commercially right now. So we're fine for a few year!!


___

### **PR Type**
Bug fix


___

### **Description**
- Fix download speed reporting 0 B/s on high-speed connections (>400 Mbps)

- Reduce speed calculation period from 1000ms to 500ms

- Increase chunk sizes for larger files to prevent premature completion

- Add progressive chunk sizing based on file size


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["High Speed Connection"] --> B["Small Chunks Downloaded"]
  B --> C["Speed Calculated Before Period"]
  C --> D["Speed Shows 0 B/s"]
  E["Reduced Period 500ms"] --> F["Larger Chunk Sizes"]
  F --> G["Speed Properly Calculated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Bandwidth.cs</strong><dd><code>Reduce speed calculation period to 500ms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DownloaderNET/Bandwidth.cs

<ul><li>Change speed calculation period from 1000ms to 500ms<br> <li> Update <code>OneSecond</code> constant to <code>Period</code> with 500ms value<br> <li> Modify speed calculation logic to use new period</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/Downloader.NET/pull/11/files#diff-288a9d70a633ba8d911edae26fc30e3a1485ff15fe8d949fe0971dc3e59b3f36">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Downloader.cs</strong><dd><code>Implement progressive chunk sizing for large files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DownloaderNET/Downloader.cs

<ul><li>Add progressive chunk sizing based on file size<br> <li> Increase chunk sizes for files >50MB, >500MB, >1GB, >4GB<br> <li> Maximum chunk size increased to 750MB for very large files<br> <li> Add detailed comments explaining the fix rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/rogerfar/Downloader.NET/pull/11/files#diff-dc8c1e62bca3c0a1b05cbae0f347059863ba0faad8f7402e9b8a3147524a3113">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

